### PR TITLE
kconfig: remove PICOLIBC_MODULE, introduce PICOLIBC_USE_MODULE

### DIFF
--- a/zephyr/Kconfig
+++ b/zephyr/Kconfig
@@ -1,8 +1,10 @@
 # Copyright © 2021 Amazon.com, Inc. or its affiliates.
 # SPDX-License-Identifier: Apache-2.0
 
-config PICOLIBC_MODULE
-	bool "picolibc module support"
+config PICOLIBC_USE_MODULE
+	bool
 	help
-	  This option builds the picolibc module. It is only used if
-	  PICOLIBC_USE_MODULE is selected.
+	  This setting enables building of Picolibc as a module.
+	  It is used by the picolibc build system but made promptless here in
+	  order to allow the build system integrating the Picolibc module to
+	  decide how and under which conditions Picolibc should be enabled.


### PR DESCRIPTION

@keith-packard maybe you prefer to take this directly here ? : https://github.com/picolibc/picolibc

----------

Remove PICOLIBC_MODULE as it is not used.
Introduce PICOLIBC_USE_MODULE as a hidden symbol. PICOLIBC_USE_MODULE is the actual Kconfig symbol used in the CMake code to decide if Picolibc should be build.

The symbol is promptless to allow external users of the module, such as Zephyr itself, to setup rules / dependencies as to when Picolibc should be built as a module.

Signed-off-by: Torsten Rasmussen <Torsten.Rasmussen@nordicsemi.no>