### PR TITLE
cmake: Guard CMAKE_BUILD_TYPE when integrating with Zephyr

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -40,7 +40,7 @@ project(Picolibc VERSION 1.8.8 LANGUAGES C ASM)
 # Set a default build type if none was specified
 set(default_build_type "MinSizeRel")
 
-if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES)
+if(NOT CMAKE_BUILD_TYPE AND NOT CMAKE_CONFIGURATION_TYPES AND NOT DEFINED ZEPHYR_BASE)
   message(STATUS "Setting build type to '${default_build_type}' as none was specified.")
   set(CMAKE_BUILD_TYPE "${default_build_type}" CACHE
       STRING "Choose the type of build." FORCE)


### PR DESCRIPTION
Zephyr controls compile and linker flags, such as optimization using Kconfig and not CMAKE_BUILD_TYPE.

Therefore disable the setting of CMAKE_BUILD_TYPE when Zephyr is used to avoid situations like `-Os -O2` when compiling Zephyr with Picolibc.