### PR TITLE
RX: Add meson.build to enable Renesas RX build

### DIFF
--- a/newlib/libc/machine/rx/meson.build
+++ b/newlib/libc/machine/rx/meson.build
@@ -1,0 +1,51 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2025 Renesas Electronics Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+srcs_machine = [
+  'memchr.S',
+  'memcpy.S',
+  'memmove.S',
+  'mempcpy.S',
+  'memset.S',
+  'setjmp.S',
+  'strcat.S',
+  'strcmp.S',
+  'strcpy.S',
+  'strlen.S',
+  'strncat.S',
+  'strncmp.S',
+  'strncpy.S',
+]
+
+src_machine = files(srcs_machine)

--- a/newlib/libc/picolib/machine/rx/interrupt.c
+++ b/newlib/libc/picolib/machine/rx/interrupt.c
@@ -1,0 +1,84 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Renesas Electronics Corporation
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+extern void _start(void);
+
+void * const __interrupt_vector[] __attribute__((section(".rodata.fvectors"))) = {
+	/* Reserved for OFSM */
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	/* Reserved area */
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	/* Reserved for ID Code */
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	/* Reserved area */
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	/* Reserved area */
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	/* 0x50: Privileged instruction exception */
+	(void *)0x10000000,            /* Reserved space on RX */
+	/* 0x54: Access exception */
+	(void *)0x10000000,            /* Reserved space on RX */
+	/* 0x58: Reserved */
+	(void *)0x10000000,            /* Reserved space on RX */
+	/* 0x5c: Undefined Instruction Exception */
+	(void *)0x10000000,            /* Reserved space on RX */
+	/* 0x60: Reserved */
+	(void *)0xFFFFFFFF,
+	/* 0x64: Floating Point Exception */
+	(void *)0x10000000,            /* Reserved space on RX */
+	/* 0x68-0x74: Reserved */
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	(void *)0xFFFFFFFF,
+	/* 0x78: Non-maskable interrupt */
+	(void *)0xFFFFFFFF,
+	_start,
+};

--- a/newlib/libc/picolib/machine/rx/meson.build
+++ b/newlib/libc/picolib/machine/rx/meson.build
@@ -1,0 +1,36 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2025 Renesas Electronics Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+src_picolib += files('interrupt.c')

--- a/picocrt/machine/rx/CMakeLists.txt
+++ b/picocrt/machine/rx/CMakeLists.txt
@@ -1,0 +1,44 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2025 Renesas Electronics Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+add_library(picocrt OBJECT crt0.c)
+add_library(picocrt-semihost OBJECT crt0.c)
+
+target_compile_options(picocrt PRIVATE ${PICOLIBC_COMPILE_OPTIONS})
+target_compile_options(picocrt-semihost PRIVATE -DCRT0_EXIT -DCRT0_SEMIHOST ${PICOLIBC_COMPILE_OPTIONS})
+
+target_include_directories(picocrt SYSTEM PUBLIC ${PICOLIBC_INCLUDE_DIRECTORIES})
+target_include_directories(picocrt-semihost SYSTEM PUBLIC ${PICOLIBC_INCLUDE_DIRECTORIES})
+

--- a/picocrt/machine/rx/crt0.S
+++ b/picocrt/machine/rx/crt0.S
@@ -1,0 +1,71 @@
+/* Copyright (c) 2008, 2009, 2011 Red Hat Incorporated.
+   All rights reserved.
+
+   Redistribution and use in source and binary forms, with or without
+   modification, are permitted provided that the following conditions
+   are met: 
+
+     Redistributions of source code must retain the above copyright 
+     notice, this list of conditions and the following disclaimer.
+
+     Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in the
+     documentation and/or other materials provided with the distribution.
+
+     The name of Red Hat Incorporated may not be used to endorse 
+     or promote products derived from this software without specific 
+     prior written permission.
+
+   This software is provided by the copyright holders and contributors
+   "AS IS" and any express or implied warranties, including, but not
+   limited to, the implied warranties of merchantability and fitness for
+   a particular purpose are disclaimed.  In no event shall Red Hat
+   incorporated be liable for any direct, indirect, incidental, special,
+   exemplary, or consequential damages (including, but not limited to,
+   procurement of substitute goods or services; loss of use, data, or
+   profits; or business interruption) however caused and on any theory of
+   liability, whether in contract, strict liability, or tort (including
+   negligence or otherwise) arising in any way out of the use of this
+   software, even if advised of the possibility of such damage.  */
+
+	.text
+
+	.global __start
+__start:
+.LFB2:
+	mvtc	#0, psw
+	/* Enable the DN bit - this should have been done for us by
+           the CPU reset, but it is best to make sure for ourselves.  */	
+	mvtc    #0x100, fpsw
+	mov	#___stack, r0
+
+	/* Copy the .data section from ROM into RAM.  */
+	mov	#___data_start, r1
+	mov	#___data_source, r2
+	mov	#___data_size, r3
+#ifdef __RX_DISALLOW_STRING_INSNS__
+	cmp	#0, r3
+	beq	2f
+
+1:	mov.b	[r2+], r5
+	mov.b	r5, [r1+]
+	sub	#1, r3
+	bne	1b
+2:	
+#else
+	smovf
+#endif
+
+	/* Initialise the contents of the .bss section.  */
+	mov	#___bss_start, r1
+	mov	#0, r2
+	mov	#___bss_size, r3
+	sstr.l	
+
+	mov	#0, r1 /* argc */
+	mov	#0, r2 /* argv */
+	mov	#0, r3 /* envv */
+	bsr.a	_main
+
+	nop
+

--- a/picocrt/machine/rx/meson.build
+++ b/picocrt/machine/rx/meson.build
@@ -1,0 +1,35 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2025 Renesas Electronics Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+src_picocrt += files('crt0.S')

--- a/scripts/cross-rx-zephyr-elf.txt
+++ b/scripts/cross-rx-zephyr-elf.txt
@@ -1,0 +1,29 @@
+[binaries]
+# Meson 0.53.2 doesn't use any cflags when doing basic compiler tests,
+# so we have to add -nostdlib to the compiler configuration itself or
+# early compiler tests will fail. This can be removed when picolibc
+# requires at least version 0.54.2 of meson.
+c = ['rx-zephyr-elf-gcc', '-nostdlib', '-nofpu', '-m64bit-doubles']
+cpp = ['rx-zephyr-elf-g++', '-nostdlib', '-nofpu', '-m64bit-doubles']
+ar = 'rx-zephyr-elf-ar'
+as = 'rx-zephyr-elf-as'
+nm = 'rx-zephyr-elf-nm'
+strip = 'rx-zephyr-elf-strip'
+exe_wrapper = ['sh', '-c', 'test -z "$PICOLIBC_TEST" || run-rx "$@"', 'run-rx']
+
+[host_machine]
+system = 'none'
+cpu_family = 'rx'
+cpu = 'rx100'
+endian = 'little'
+
+[properties]
+skip_sanity_check = true
+default_flash_addr = '0xfff80000'
+default_flash_size = '0x00080000'
+default_ram_addr   = '0x00000000'
+default_ram_size   = '0x00018000'
+additional_sections = ['fvector']
+default_fvector_addr = '0xffffff80'
+default_fvector_size = '0x00000080'
+default_fvector_contents = ['KEEP (*(.rodata.fvector*))']

--- a/scripts/do-rx-zephyr-elf-configure
+++ b/scripts/do-rx-zephyr-elf-configure
@@ -1,0 +1,45 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2025 Renesas Electronics Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+PREFIX=$HOME/zephyr-sdk
+ARCH=rx-zephyr-elf
+multilib_list="no-fpu-libs,64-bit-double,big-endian-data,no-strings"
+
+exec "$(dirname "$0")"/do-configure "$ARCH" \
+    -Dprefix="$PREFIX" \
+    -Dtests=true \
+    -Dtests-enable-posix-io=false \
+    -Dtests-enable-stack-protector=false \
+    -Dmultilib-list="$multilib_list" "$@"

--- a/scripts/run-rx
+++ b/scripts/run-rx
@@ -1,0 +1,56 @@
+#!/bin/sh
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2025 Renesas Electronics Corporation
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+dir="$(dirname "$0")"
+
+# select the program
+elf="$1"
+shift
+
+qemu="qemu-system-rx"
+cpu=rx62n
+
+"$dir"/monitor-e9 $qemu \
+  -chardev stdio,id=con,mux=on \
+  -machine gdbsim-r5f562n8 \
+  -cpu $cpu \
+  -serial chardev:con \
+  -mon chardev=con,mode=readline \
+  -net none \
+  -nographic \
+  -bios "$elf" < /dev/null
+
+#gxemul -E testsh "$elf"

--- a/semihost/machine/rx/meson.build
+++ b/semihost/machine/rx/meson.build
@@ -1,0 +1,66 @@
+#
+# SPDX-License-Identifier: BSD-3-Clause
+#
+# Copyright © 2021 Keith Packard
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#
+# 1. Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#
+# 2. Redistributions in binary form must reproduce the above
+#    copyright notice, this list of conditions and the following
+#    disclaimer in the documentation and/or other materials provided
+#    with the distribution.
+#
+# 3. Neither the name of the copyright holder nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+# "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+# LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+# FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+# COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+# INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+# (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+# SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+# HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+# STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+# OF THE POSSIBILITY OF SUCH DAMAGE.
+#
+
+lib_semihost_srcs = [
+  'rx_stub.c',
+  'rx_exit.c',
+  'rx_iob.c',
+  ]
+
+has_semihost = true
+
+foreach target : targets
+  value = get_variable('target_' + target)
+
+  instdir = join_paths(lib_dir, value[0])
+
+  if target == ''
+    libsemihost_name = 'semihost'
+  else
+    libsemihost_name = join_paths(target, 'libsemihost')
+  endif
+
+  local_lib_semihost_target = static_library(libsemihost_name,
+				       lib_semihost_srcs,
+				       install : true,
+				       install_dir : instdir,
+				       include_directories : inc,
+				       c_args : value[1] + c_args,
+				       pic: false)
+
+  set_variable('lib_semihost' + target, local_lib_semihost_target)
+
+endforeach
+

--- a/semihost/machine/rx/rx_exit.c
+++ b/semihost/machine/rx/rx_exit.c
@@ -1,0 +1,50 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <unistd.h>
+#include "rx_semihost.h"
+
+_Noreturn void
+_exit(int code)
+{
+        char buf[15];
+        int n;
+        /* Can't use printf because stdout has already been cleaned up */
+        n = snprintf(buf, sizeof(buf), "%cexit %d\n", 0xe9, code);
+        write(1, buf, n);
+	while(1);
+}

--- a/semihost/machine/rx/rx_iob.c
+++ b/semihost/machine/rx/rx_iob.c
@@ -1,0 +1,118 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#include "rx_semihost.h"
+
+typedef volatile uint8_t vuint8_t;
+typedef volatile uint32_t vuint32_t;
+
+struct sci {
+    vuint8_t    smr;
+    vuint8_t    brr;
+    vuint8_t    scr;
+    vuint8_t    tdr;
+
+    vuint8_t    ssr;
+    vuint8_t    rdr;
+    vuint8_t    scmr;
+    vuint8_t    semr;
+};
+
+/* SCI SCR fields */
+#define SCI_SCR_CKE_0   (1 <<  0)
+#define SCI_SCR_CKE_1   (2 <<  0)
+#define SCI_SCR_TEIE    (1 <<  2)
+#define SCI_SCR_MPIE    (1 <<  3)
+#define SCI_SCR_RE      (1 <<  4)
+#define SCI_SCR_TE      (1 <<  5)
+#define SCI_SCR_RIE     (1 <<  6)
+#define SCI_SCR_TIE     (1 <<  7)
+
+/* SCI SSR fields */
+#define SCI_SSR_MPBT    (1 << 0)
+#define SCI_SSR_MPB     (1 << 1)
+#define SCI_SSR_TEND    (1 << 2)
+#define SCI_SSR_PER     (1 << 3)
+#define SCI_SSR_FER     (1 << 4)
+#define SCI_SSR_ORER    (1 << 5)
+#define SCI_SSR_RDRF    (1 << 6)
+#define SCI_SSR_TDRE    (1 << 7)
+
+#ifdef __GNUCLIKE_PRAGMA_DIAGNOSTIC
+#pragma GCC diagnostic ignored "-Wpragmas"
+#pragma GCC diagnostic ignored "-Wunknown-warning-option"
+/* 'bsize' is used directly with malloc/realloc which confuses -fanalyzer */
+#pragma GCC diagnostic ignored "-Warray-bounds"
+#endif
+
+/* rx62n serial port */
+#define SCI0    (*((struct sci *) 0x00088240))
+
+int
+rx_putc(char c, FILE *file)
+{
+	(void) file;
+        SCI0.scr |= SCI_SCR_TE;
+        while ((SCI0.ssr & SCI_SSR_TEND) == 0)
+               ;
+        SCI0.tdr = (uint8_t) c;
+	return (unsigned char) c;
+}
+
+#ifdef TINY_STDIO
+
+static int
+rx_getc(FILE *file)
+{
+	(void) file;
+        SCI0.scr |= SCI_SCR_RE;
+        while ((SCI0.ssr & SCI_SSR_RDRF) == 0)
+            ;
+        return (unsigned char) SCI0.rdr;
+}
+
+static FILE __stdio = FDEV_SETUP_STREAM(rx_putc, rx_getc, NULL, _FDEV_SETUP_RW);
+
+#ifdef __strong_reference
+#define STDIO_ALIAS(x) __strong_reference(stdin, x);
+#else
+#define STDIO_ALIAS(x) FILE *const x = &__stdio;
+#endif
+
+FILE *const stdin = &__stdio;
+STDIO_ALIAS(stdout);
+STDIO_ALIAS(stderr);
+
+#endif

--- a/semihost/machine/rx/rx_semihost.h
+++ b/semihost/machine/rx/rx_semihost.h
@@ -1,0 +1,52 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2025 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#ifndef _RX_SEMIHOST_H_
+#define _RX_SEMIHOST_H_
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <unistd.h>
+#include <sys/types.h>
+#include <sys/stat.h>
+
+int
+rx_putc(char c, FILE *file);
+
+#endif /* _RX_SEMIHOST_H_ */

--- a/semihost/machine/rx/rx_stub.c
+++ b/semihost/machine/rx/rx_stub.c
@@ -1,0 +1,108 @@
+/*
+ * SPDX-License-Identifier: BSD-3-Clause
+ *
+ * Copyright © 2021 Keith Packard
+ *
+ * Redistribution and use in source and binary forms, with or without
+ * modification, are permitted provided that the following conditions
+ * are met:
+ *
+ * 1. Redistributions of source code must retain the above copyright
+ *    notice, this list of conditions and the following disclaimer.
+ *
+ * 2. Redistributions in binary form must reproduce the above
+ *    copyright notice, this list of conditions and the following
+ *    disclaimer in the documentation and/or other materials provided
+ *    with the distribution.
+ *
+ * 3. Neither the name of the copyright holder nor the names of its
+ *    contributors may be used to endorse or promote products derived
+ *    from this software without specific prior written permission.
+ *
+ * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+ * "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+ * LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS
+ * FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+ * COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT,
+ * INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ * (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+ * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+ * HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT,
+ * STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+ * ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED
+ * OF THE POSSIBILITY OF SUCH DAMAGE.
+ */
+
+#define _GNU_SOURCE
+#include "rx_semihost.h"
+
+ssize_t
+read(int fd, void *buf, size_t count)
+{
+        (void) fd;
+        (void) buf;
+        (void) count;
+	return 0;
+}
+
+ssize_t
+write(int fd, const void *buf, size_t count)
+{
+	const char *b = buf;
+	size_t c = count;
+
+        (void) fd;
+	while (c--)
+                rx_putc(*b++, NULL);
+	return count;
+}
+
+int
+open(const char *pathname, int flags, ...)
+{
+        (void) pathname;
+        (void) flags;
+	return -1;
+}
+
+int
+close(int fd)
+{
+        (void) fd;
+	return 0;
+}
+
+off_t lseek(int fd, off_t offset, int whence)
+{
+        (void) fd;
+        (void) offset;
+        (void) whence;
+	return (off_t) -1;
+}
+
+_off64_t lseek64(int fd, _off64_t offset, int whence)
+{
+	return (_off64_t) lseek(fd, (off_t) offset, whence);
+}
+
+int
+unlink(const char *pathname)
+{
+        (void) pathname;
+	return 0;
+}
+
+int
+fstat (int fd, struct stat *sbuf)
+{
+        (void) fd;
+        (void) sbuf;
+	return -1;
+}
+
+int
+isatty (int fd)
+{
+        (void) fd;
+	return 1;
+}


### PR DESCRIPTION
Add meson.build to enable picolibc for rx-zephyr-elf